### PR TITLE
feat: add configurable script timeout

### DIFF
--- a/src/main/java/com/deque/axe/AXE.java
+++ b/src/main/java/com/deque/axe/AXE.java
@@ -236,6 +236,7 @@ public class AXE {
 		private final List<String> excludes = new ArrayList<String>();
 		private String options = "{}";
 		private Boolean skipFrames = false;
+		private int timeout = 30;
 
 		/**
 		 * Initializes the Builder class to chain configuration before analyzing pages.
@@ -245,6 +246,15 @@ public class AXE {
 		public Builder(final WebDriver driver, final URL script) {
 			this.driver = driver;
 			this.script = script;
+		}
+
+		/**
+		 * Set the script timeout.
+		 * @param timeout
+		 */
+		public Builder setTimeout(int timeout) {
+			this.timeout = timeout;
+			return this;
 		}
 
 		/**
@@ -321,7 +331,7 @@ public class AXE {
 		private JSONObject execute(final String command, final Object... args) {
 			AXE.inject(this.driver, this.script, this.skipFrames);
 
-			this.driver.manage().timeouts().setScriptTimeout(30, TimeUnit.SECONDS);
+			this.driver.manage().timeouts().setScriptTimeout(this.timeout, TimeUnit.SECONDS);
 
 			Object response = ((JavascriptExecutor) this.driver).executeAsyncScript(command, args);
 

--- a/src/test/java/com/deque/axe/ExampleTest.java
+++ b/src/test/java/com/deque/axe/ExampleTest.java
@@ -111,6 +111,26 @@ public class ExampleTest {
 		}
 	}
 
+	@Test
+	public void testCustomTimeout() {
+		driver.get("http://localhost:5005");
+
+		boolean didTimeout = false;
+		try {
+			new AXE.Builder(driver, ExampleTest.class.getResource("/timeout.js"))
+				.setTimeout(1)
+				.analyze();
+		} catch (Exception e) {
+			String msg = e.getMessage();
+			if (msg.indexOf("1 seconds") == -1) {
+				assertTrue("Did not error with timeout message", msg.indexOf("1 seconds") != -1);
+			}
+			didTimeout = true;
+		}
+
+		assertTrue("Did set custom timeout", didTimeout);
+	}
+
 	/**
 	 * Test a specific selector or selectors
 	 */

--- a/src/test/resources/timeout.js
+++ b/src/test/resources/timeout.js
@@ -1,0 +1,8 @@
+// A fake axe-core that takes 5 minutes to finish
+window.axe = {
+  run: function (context, options, callback) {
+    setTimeout(function () {
+      callback()
+    }, 1000 * 60 * 5)
+  }
+}


### PR DESCRIPTION
This patch adds a `Builder#setTimeout` method for setting a configurable script timeout. Prior to this, we'd always timeout after 30 seconds.

Closes #17.