### PR TITLE
Fix readme to update version to 3.0 from 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ To run the example tests on your own web page, change the URL passed to `driver.
 
 ## To use the AXE helper library in your own tests
 
-Include this library as a test-scoped dependency in your POM:
+Include this library as a test-scoped dependency in your POM. Ensure the `version` matches the one in `[pom.xml](./pom.xml)`:
 
 ```xml
 <dependency>
   <groupId>com.deque</groupId>
   <artifactId>axe-selenium</artifactId>
-  <version>2.0</version>
+  <version>3.0</version>
   <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
Fix readme to update version to 3.0 from 2.0

Closes issue: https://github.com/dequelabs/axe-selenium-java/issues/35

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen