### PR TITLE
Fix work witn few include and exclude options

### DIFF
--- a/src/main/java/com/deque/axe/AXE.java
+++ b/src/main/java/com/deque/axe/AXE.java
@@ -315,23 +315,19 @@ public class AXE {
 		 */
 		public JSONObject analyze() {
 			String axeContext;
-			String axeOptions;
 
 			if (includes.size() > 1 || excludes.size() > 0) {
 				String includesJoined = "['" + StringUtils.join(includes, "'],['") + "']";
 				String excludesJoined = excludes.size() == 0 ? "" : "['" + StringUtils.join(excludes, "'],['") + "']";
 
-				axeContext = "document";
-				axeOptions = String.format("{ include: [%s], exclude: [%s] }", includesJoined, excludesJoined);
+				axeContext = String.format("{ include: [%s], exclude: [%s] }", includesJoined, excludesJoined);
 			} else if (includes.size() == 1) {
 				axeContext = String.format("'%s'", this.includes.get(0).replace("'", ""));
-				axeOptions = options;
 			} else {
 				axeContext = "document";
-				axeOptions = options;
 			}
 
-			String snippet = getAxeSnippet(axeContext, axeOptions);
+			String snippet = getAxeSnippet(axeContext, options);
 			return execute(snippet);
 		}
 

--- a/src/test/java/com/deque/axe/ExampleTest.java
+++ b/src/test/java/com/deque/axe/ExampleTest.java
@@ -158,9 +158,9 @@ public class ExampleTest {
 	 */
 	@Test
 	public void testAccessibilityWithIncludesAndExcludes() {
-		driver.get("http://localhost:5005");
+		driver.get("http://localhost:5005/include-exclude.html");
 		JSONObject responseJSON = new AXE.Builder(driver, scriptUrl)
-				.include("div")
+				.include("body")
 				.exclude("h1")
 				.analyze();
 
@@ -235,5 +235,50 @@ public class ExampleTest {
 		}
 
 		assertTrue("Did raise axe-core error", didError);
+	}
+
+	/**
+	 * Test few include
+	 */
+	@Test
+	public void testAccessibilityWithFewInclude() {
+		driver.get("http://localhost:5005/include-exclude.html");
+		JSONObject responseJSON = new AXE.Builder(driver, scriptUrl)
+				.include("div")
+				.include("p")
+				.analyze();
+
+		JSONArray violations = responseJSON.getJSONArray("violations");
+
+		if (violations.length() == 0) {
+			assertTrue("No violations found", true);
+		} else {
+			AXE.writeResults(testName.getMethodName(), responseJSON);
+			assertTrue(AXE.report(violations), false);
+		}
+	}
+
+	/**
+	 * Test includes and excludes with violation
+	 */
+	@Test
+	public void testAccessibilityWithIncludesAndExcludesWithViolation() {
+		driver.get("http://localhost:5005/include-exclude.html");
+		JSONObject responseJSON = new AXE.Builder(driver, scriptUrl)
+				.include("body")
+				.exclude("div")
+				.analyze();
+
+		JSONArray violations = responseJSON.getJSONArray("violations");
+
+		JSONArray nodes = ((JSONObject)violations.get(0)).getJSONArray("nodes");
+		JSONArray target = ((JSONObject)nodes.get(0)).getJSONArray("target");
+
+		if (violations.length() == 1) {
+			assertEquals(String.valueOf(target), "[\"span\"]");
+		} else {
+			AXE.writeResults(testName.getMethodName(), responseJSON);
+			assertTrue("No violations found", false);
+		}
 	}
 }

--- a/src/test/resources/test-app.js
+++ b/src/test/resources/test-app.js
@@ -2,8 +2,8 @@
  * Test target application that just serves a simple HTML page
  */
 require('http').createServer(function (req, res) {
-	if(req.url === '/shadow-error.html') {
-		res.writeHead(200, { 'Content-Type': 'text/html' });
+    if (req.url === '/shadow-error.html') {
+        res.writeHead(200, {'Content-Type': 'text/html'});
         res.end(`
 			<!doctype html>
 			<html lang="en">
@@ -23,8 +23,25 @@ require('http').createServer(function (req, res) {
 				</body>
 			</html>
 		`);
-	} else {
-        res.writeHead(200, { 'Content-Type': 'text/html' });
+    } else if (req.url === '/include-exclude.html') {
+        res.writeHead(200, {'Content-Type': 'text/html'});
+        res.end(`
+    			<!doctype html>
+    			<html lang="en">
+    				<head>
+    					<title>Test Page</title>
+    				</head>
+    				<body>
+    				<h1><span style="color: yellow">This is a yellow text</span></h1>
+    					<div role="main" id="host">
+    						<p>This is a test page with violation</p>
+    					</div>
+    					<p>This page is required to verify collaborative operation .include and .exclude</p>
+    				</body>
+    			</html>
+    		`);
+    } else {
+        res.writeHead(200, {'Content-Type': 'text/html'});
         res.end(`
 			<!doctype html>
 			<html lang="en">
@@ -44,6 +61,6 @@ require('http').createServer(function (req, res) {
 				</body>
 			</html>
 	`);
-	}
+    }
 
 }).listen('5005');


### PR DESCRIPTION
According to the documentation, include and exclude should not be passed in options. 
They should be passed as context.
Also added tests to catch this error.

Closes issue: #42

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Adam Cutler